### PR TITLE
CMS 5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # Mailblock
+
 Adds email redirection options to the CMS.
 
 ## Requirements
-* [SilverStripe CMS ^4](https://github.com/silverstripe/silverstripe-cms)
 
+* [SilverStripe admin ^5](https://github.com/silverstripe/silverstripe-admin)
+
+SilverStripe 4 support is available in the [2.0 branch](https://github.com/signify-nz/silverstripe-mailblock/tree/2.0)
 SilverStripe 3 support is available in the [1.0 branch](https://github.com/signify-nz/silverstripe-mailblock/tree/1.0)
 
 ## Installation
-__Composer (recommended):__
+
 ```
 composer require signify-nz/silverstripe-mailblock
 ```
 
-If you prefer you may also install manually:
-* Download the module from here https://github.com/signify-nz/silverstripe-mailblock/archive/master.zip
-* Extract the downloaded archive into your site root so that the destination folder is called silverstripe-mailblock.
-* Run dev/build?flush to regenerate the manifest
-
 ## Usage
+
 All options are in the Settings -> Mailblock section of the CMS. Only users with the "Access to 'Mailblock' settings" permission will be able to configure Mailblock.
 
 ## Limitations
-This module works by adding an additional SwiftMailer (the Mailer included with SilverStripe) plugin. If you are using a custom mailer, no email recipient rewritting will take place.
+
+This module works by adding an additional Symfony mailer (the Mailer included with SilverStripe) event subscriber. If you are using a custom mailer, no email recipient rewriting will take place.
 
 [User Guide](/docs/en/user_guide.md)

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,14 +1,17 @@
 ---
 Name: mailblockconfig
 After:
-  - '#emailconfig'
+  - '#mailer'
 ---
 SilverStripe\SiteConfig\SiteConfig:
   extensions:
     - Mailblock\extensions\MailblockSiteConfig
+
 SilverStripe\SiteConfig\SiteConfigLeftAndMain:
   extensions:
     - Mailblock\extensions\MailblockSiteConfigLeftAndMain
-SilverStripe\Control\Email\SwiftMailer:
-  swift_plugins: 
-    - Mailblock\Email\MailblockPlugin
+
+SilverStripe\Core\Injector\Injector:
+  Symfony\Component\EventDispatcher\EventDispatcherInterface.mailer:
+    calls:
+      - [addSubscriber, ['%$Mailblock\Email\MailblockMailSubscriber']]

--- a/code/extensions/MailblockSiteConfigLeftAndMain.php
+++ b/code/extensions/MailblockSiteConfigLeftAndMain.php
@@ -31,12 +31,12 @@ class MailblockSiteConfigLeftAndMain extends LeftAndMainExtension
             $siteConfig = SiteConfig::current_site_config();
         }
 
-        $to = $siteConfig->getField('MailblockTestTo');
-        $from = $siteConfig->getField('MailblockTestFrom');
-        $subject = $siteConfig->getField('MailblockTestSubject');
-        $body = $siteConfig->getField('MailblockTestBody');
-        $cc = $siteConfig->getField('MailblockTestCc');
-        $bcc = $siteConfig->getField('MailblockTestBcc');
+        $to = $siteConfig->getField('MailblockTestTo') ?? '';
+        $from = $siteConfig->getField('MailblockTestFrom') ?? '';
+        $subject = $siteConfig->getField('MailblockTestSubject') ?? '';
+        $body = $siteConfig->getField('MailblockTestBody') ?? '';
+        $cc = $siteConfig->getField('MailblockTestCc') ?? '';
+        $bcc = $siteConfig->getField('MailblockTestBcc') ?? '';
         $email = new Email($from, $to, $subject, $body, $cc, $bcc);
         $email->send();
 

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         "issues": "http://github.com/signify-nz/silverstripe-mailblock/issues"
     },
     "require": {
-        "silverstripe/framework": "^4",
-        "silverstripe/siteconfig": "^4"
+        "silverstripe/framework": "^5",
+        "silverstripe/siteconfig": "^5"
     },
     "extra": {
         "expose": [


### PR DESCRIPTION
Adds CMS 5 compatibility - works with the beta, and with the change freeze on API breaking changes it should work with stable when that's released too.

It'll probably pay to write some unit or behat tests for this (there's some nifty email helper stuff with behat tests where you can check if emails were sent, to whom, what they contained, etc) but since there weren't tests before I won't be adding them in this PR.